### PR TITLE
pre-commit updates with formatting changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,29 +12,21 @@ repos:
       - id: debug-statements
       - id: mixed-line-ending
 
-  # Adds a standard feel to import segments, adds future annotations
-  - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
+  # Adds a standard feel to import segments
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
-      - id: reorder-python-imports
+      - id: isort
         args:
-          - "--py37-plus"
+          - "--force-single-line-imports"
           - "--add-import"
           - "from __future__ import annotations"
-          - "--application-directories"
-          - ".:src"
-
-  # Automatically upgrade syntax to newer versions
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - "--py38-plus"
+          - "--profile"
+          - "black"
 
   # Format code. No, I don't like everything black does either.
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
 

--- a/src/wypt/_filters.py
+++ b/src/wypt/_filters.py
@@ -1,4 +1,5 @@
 """Custom filters applied in Jinja2 templates."""
+
 from __future__ import annotations
 
 import datetime

--- a/src/wypt/api_handler.py
+++ b/src/wypt/api_handler.py
@@ -1,4 +1,5 @@
 """Process requetss from API and return results."""
+
 from __future__ import annotations
 
 import logging

--- a/src/wypt/cli.py
+++ b/src/wypt/cli.py
@@ -1,4 +1,5 @@
 """WIP - Placeholder for CLI interface."""
+
 from __future__ import annotations
 
 from .paste_scanner import PasteScanner

--- a/src/wypt/database.py
+++ b/src/wypt/database.py
@@ -1,4 +1,5 @@
 """Read/Write actions to the sqlite3 database."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/src/wypt/exceptions.py
+++ b/src/wypt/exceptions.py
@@ -1,4 +1,5 @@
 """Custom exceptions for project."""
+
 from __future__ import annotations
 
 import time

--- a/src/wypt/model.py
+++ b/src/wypt/model.py
@@ -1,4 +1,5 @@
 """Data models for API responses."""
+
 from __future__ import annotations
 
 import dataclasses

--- a/src/wypt/paste_scanner.py
+++ b/src/wypt/paste_scanner.py
@@ -1,6 +1,7 @@
 """
 Gather and scan paste data from pastebin.
 """
+
 from __future__ import annotations
 
 import logging

--- a/src/wypt/pastebin_api.py
+++ b/src/wypt/pastebin_api.py
@@ -8,6 +8,7 @@ Scraping endpoints of pastebin do not, generally, return error statuses
 even on invalid requests. Due to this, any error status will raise a
 ResponseError exception.
 """
+
 from __future__ import annotations
 
 import json

--- a/src/wypt/pattern_config.py
+++ b/src/wypt/pattern_config.py
@@ -1,4 +1,5 @@
 """Scan a string for patterns of interest."""
+
 from __future__ import annotations
 
 import logging

--- a/src/wypt/runtime.py
+++ b/src/wypt/runtime.py
@@ -1,4 +1,5 @@
 """Runtime setup actions and config loading."""
+
 from __future__ import annotations
 
 import logging

--- a/tests/runtime_time_test.py
+++ b/tests/runtime_time_test.py
@@ -6,8 +6,8 @@ import pytest
 
 from wypt.database import Database
 from wypt.pattern_config import PatternConfig
-from wypt.runtime import _Config
 from wypt.runtime import Runtime
+from wypt.runtime import _Config
 
 TEST_CONFIG = "tests/fixture/wypt.toml"
 TEST_PATTERNS = {"Basic Email", "Broken Pattern", "Discord Webhook", "JWT Token"}


### PR DESCRIPTION
black 24.1 formatting changes

Do to conflicts against the format of `black`, the tool `reorder-python-imports` is replaced with `isort`.

Removing `pyupgrade` to reduce tool opinionation further.